### PR TITLE
Update to work with Rails 5.1

### DIFF
--- a/crystalmeta.gemspec
+++ b/crystalmeta.gemspec
@@ -8,16 +8,17 @@ Gem::Specification.new do |gem|
   gem.version       = Crystal::VERSION
   gem.authors       = ["Max Savchenko"]
   gem.email         = ["robotector@gmail.com"]
-  gem.description   = %q{Crystal clean meta tags for Rails applications. Support I18n. Perfect for OpenGraph.}
+  gem.description   = %q{Crystal clean meta tags for Rails applications. Supports I18n. Perfect for OpenGraph.}
   gem.summary       = %q{Crystalmeta helps you control meta tags through I18n and/or manually. It plays well with OpenGraph.}
-  gem.homepage      = "http://github.com/macovsky/crystalmeta"
+  gem.homepage      = "https://github.com/macovsky/crystalmeta"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("rails", ">= 3.0.0")
-  gem.add_development_dependency 'rspec-rails', '~> 2.12'
-  gem.add_development_dependency 'capybara', '~> 2.0.1'
+  gem.add_dependency 'rails', '>= 5.1.0'
+  gem.add_development_dependency 'rspec-rails', '~> 3.6.0'
+  gem.add_development_dependency 'rspec-its', '~> 1.2.0'
+  gem.add_development_dependency 'capybara', '~> 2.15.4'
 end

--- a/crystalmeta.gemspec
+++ b/crystalmeta.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rails', '>= 5.1.0'
   gem.add_development_dependency 'rspec-rails', '~> 3.6.0'
-  gem.add_development_dependency 'rspec-its', '~> 1.2.0'
   gem.add_development_dependency 'capybara', '~> 2.15.4'
 end

--- a/lib/crystal/controller_extensions.rb
+++ b/lib/crystal/controller_extensions.rb
@@ -1,7 +1,7 @@
 module Crystal
   module ControllerExtensions
     def self.included(base)
-      base.before_filter :_set_meta
+      base.before_action :_set_meta
       base.helper_method :meta
     end
 

--- a/lib/crystal/railtie.rb
+++ b/lib/crystal/railtie.rb
@@ -3,7 +3,7 @@ require 'rails/railtie'
 module Crystal
   class Railtie < Rails::Railtie
     initializer 'crystalmeta.setup_action_controller' do |app|
-      ActiveSupport.on_load :action_controller do
+      ActiveSupport.on_load :action_controller_base do
         Crystal.setup_action_controller self
       end
     end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -20,6 +20,8 @@ module Dummy
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
 
+    config.eager_load = false
+
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
@@ -56,9 +58,9 @@ module Dummy
     # config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
-    config.assets.enabled = false
+    # config.assets.enabled = false
 
     # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
+    # config.assets.version = '1.0'
   end
 end

--- a/spec/features/meta_tags_spec.rb
+++ b/spec/features/meta_tags_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe 'meta tags' do
+RSpec.describe 'meta tags', type: :feature do
   def meta_tags(pattern = //)
-    all('meta').select{|meta| pattern === meta[:property] || pattern === meta[:name] }
+    all(:css, 'meta', visible: :hidden).select{|meta| pattern === meta[:property] || pattern === meta[:name] }
   end
 
   def value_for(pattern = //)

--- a/spec/features/meta_tags_spec.rb
+++ b/spec/features/meta_tags_spec.rb
@@ -19,23 +19,23 @@ RSpec.describe 'meta tags', type: :feature do
     end
 
     it 'include og:title from controller' do
-      value_for('og:title').should == 'The Rock (1996)'
+      expect(value_for('og:title')).to eq 'The Rock (1996)'
     end
 
     it 'include og:image from locale' do
-      value_for('og:image').should == '/images/rock.jpg'
+      expect(value_for('og:image')).to eq '/images/rock.jpg'
     end
 
     it 'include og:image from locale' do
-      value_for('twitter:card').should == 'summary'
+      expect(value_for('twitter:card')).to eq 'summary'
     end
 
     it 'include og:type from controller defaults' do
-      value_for('og:type').should == 'video.movie'
+      expect(value_for('og:type')).to eq 'video.movie'
     end
 
-    it 'include title with interpolation' do
-      title.should == 'The Rock (1996) - IMDb'
+    it 'include title expect(with interpolation' do
+      expect(title).to eq 'The Rock (1996) - IMDb'
     end
   end
 
@@ -45,12 +45,12 @@ RSpec.describe 'meta tags', type: :feature do
     end
 
     it 'include og:title & og:type from views' do
-      value_for('og:title').should == 'Movies'
-      value_for('og:type').should == 'article'
+      expect(value_for('og:title')).to eq 'Movies'
+      expect(value_for('og:type')).to eq 'article'
     end
 
     it 'include default title' do
-      title.should == 'Movies on IMDb'
+      expect(title).to eq 'Movies on IMDb'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 
 require 'rspec/rails'
+require 'rspec/its'
 require 'capybara/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 
 require 'rspec/rails'
-require 'rspec/its'
 require 'capybara/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!

--- a/spec/unit/hash_with_stringify_keys_spec.rb
+++ b/spec/unit/hash_with_stringify_keys_spec.rb
@@ -7,16 +7,16 @@ describe Crystal::HashWithStringifyKeys do
 
   context '.new' do
     it 'stringifies keys when hash is passed' do
-      new(:key => {:key2 => 1}).should == {'key' => {'key2' => 1}}
+      expect(new(key: {key2: 1})).to eq Hash['key' => {'key2' => 1}]
     end
 
     it 'keeps a default value if one argument has been passed' do
-      new(1)['unknown'].should == 1
+      expect(new(1)['unknown']).to eq 1
     end
 
     it 'returns an empty hash when no args have been passed' do
-      new.should be_empty
-      new['unknown'].should be_nil
+      expect(new).to be_empty
+      expect(new['unknown']).to be_nil
     end
   end
 
@@ -24,8 +24,8 @@ describe Crystal::HashWithStringifyKeys do
     it 'returns a hash with stringified keys' do
       hash = new(:key => {:key2 => 1})
       merge = hash.deep_merge!(new(:key => {:key2 => 2}))
-      merge.should == {'key' => {'key2' => 2}}
-      merge.should be_kind_of(Crystal::HashWithStringifyKeys)
+      expect(merge).to eq Hash['key' => {'key2' => 2}]
+      expect(merge).to be_kind_of(Crystal::HashWithStringifyKeys)
     end
   end
 end

--- a/spec/unit/meta_spec.rb
+++ b/spec/unit/meta_spec.rb
@@ -9,7 +9,7 @@ describe Crystal::Meta do
     it 'stringifies keys' do
       subject.store :title => 'something'
       subject.store :head => 'something else'
-      options.should == {'title' => 'something', 'head' => 'something else'}
+      expect(options).to eq Hash['title' => 'something', 'head' => 'something else']
     end
 
     it 'merges options deeply' do
@@ -28,14 +28,14 @@ describe Crystal::Meta do
         :"fb:admins" => '322132'
       })
 
-      options.should == {
+      expect(options).to eq Hash[
         'og' => {
           'title' => 'og title',
           'site_name' => 'site name 2',
           'url' => 'something',
         },
         'fb:admins' => '322132'
-      }
+      ]
     end
   end
 end

--- a/spec/unit/tag_spec.rb
+++ b/spec/unit/tag_spec.rb
@@ -1,14 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe Crystal::Tag do
-  subject { Crystal::Tag.new('og:title', 'Caesar must die') }
-  its(:name) {should == 'og:title'}
-  its(:value) {should == 'Caesar must die'}
-  its(:name_key) { should == :property }
+  context 'for OpenGraph' do
+    let(:og_tag) { tag('og:title', 'Caesar must die') }
 
-  context 'for twitter' do
-    subject { Crystal::Tag.new('twitter:title', 'Caesar must die') }
-    its(:name_key) { should == :name  }
+    it 'has a name of og:title' do
+      expect(og_tag.name).to eq 'og:title'
+    end
+
+    it 'has a value of ‘Caesar must die’' do
+      expect(og_tag.value).to eq 'Caesar must die'
+    end
+
+    it 'has a name_key of :property' do
+      expect(og_tag.name_key).to eq :property
+    end
+  end
+
+  context 'for Twitter' do
+    it 'has a name_key of :name' do
+      expect(tag('twitter:title', 'Caesar must die').name_key).to eq :name
+    end
   end
 
   describe '#value_for_context' do
@@ -17,21 +29,21 @@ RSpec.describe Crystal::Tag do
     it 'returns asset path if asset' do
       image = '1.png'
       asset_path = "/assets/#{image}"
-      context.should_receive('image_path').with(image).and_return(asset_path)
-      tag('og:image', image).value_for_context(context).should == asset_path
+      allow(context).to receive('image_path').with(image).and_return(asset_path)
+      expect(tag('og:image', image).value_for_context(context)).to eq asset_path
     end
 
     it 'returns iso8601 for date' do
-      tag('date', Date.parse('1979-12-09')).value_for_context(context).should == '1979-12-09'
+      expect(tag('date', Date.parse('1979-12-09')).value_for_context(context)).to eq '1979-12-09'
     end
 
     it 'returns iso8601 for time' do
-      tag('date', DateTime.parse('1979-12-09 13:09')).value_for_context(context).should == '1979-12-09T13:09:00+00:00'
+      expect(tag('date', DateTime.parse('1979-12-09 13:09')).value_for_context(context)).to eq '1979-12-09T13:09:00+00:00'
     end
 
     it 'returns original value otherwise' do
-      tag('og:image:width', 100).value_for_context(context).should == 100
-      tag('published', true).value_for_context(context).should be true
+      expect(tag('og:image:width', 100).value_for_context(context)).to eq 100
+      expect(tag('published', true).value_for_context(context)).to be true
     end
   end
 end

--- a/spec/unit/tag_spec.rb
+++ b/spec/unit/tag_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Crystal::Tag do
+RSpec.describe Crystal::Tag do
   subject { Crystal::Tag.new('og:title', 'Caesar must die') }
   its(:name) {should == 'og:title'}
   its(:value) {should == 'Caesar must die'}
@@ -31,7 +31,7 @@ describe Crystal::Tag do
 
     it 'returns original value otherwise' do
       tag('og:image:width', 100).value_for_context(context).should == 100
-      tag('published', true).value_for_context(context).should be_true
+      tag('published', true).value_for_context(context).should be true
     end
   end
 end

--- a/spec/unit/tags_spec.rb
+++ b/spec/unit/tags_spec.rb
@@ -7,29 +7,29 @@ describe Crystal::Tags do
 
   context '#tags' do
     it 'folds hashes' do
-      new({
+      expect(new({
         'og' => {
           'title' => 'Caesar must die'
         }
-      }).tags.should == [
+      }).tags).to eq [
         tag('og:title', 'Caesar must die')
       ]
     end
 
     it 'sorts keys in hashes alphabetically' do
-      new({
+      expect(new({
         'og' => {
           'type' => 'book',
           'title' => 'One day of Ivan Denisovich'
         }
-      }).tags.should == [
+      }).tags).to eq [
         tag('og:title', 'One day of Ivan Denisovich'),
         tag('og:type', 'book')
       ]
     end
 
     it 'moves url key to the top' do
-      new({
+      expect(new({
         'og' => {
           'image' => [
             {
@@ -44,7 +44,7 @@ describe Crystal::Tags do
             },
           ]
         }
-      }).tags.should == [
+      }).tags).to eq [
         tag('og:image:url', '1.png'),
         tag('og:image:height', 300),
         tag('og:image:width', 200),
@@ -55,21 +55,21 @@ describe Crystal::Tags do
     end
 
     it 'duplicates tags for arrays' do
-      new('og:image' => ['1.png', '2.png']).tags.should == [
+      expect(new('og:image' => ['1.png', '2.png']).tags).to eq [
         tag('og:image', '1.png'),
         tag('og:image', '2.png')
       ]
     end
 
     it 'interpolates values' do
-      new({
+      expect(new({
         :og => {
           :title     => 'The Rock (%{year})',
           :site_name => 'IMDb'
         },
         :year => 1996,
         :head => '%{og:title} - %{og:site_name}'
-      }).tags.should == [
+      }).tags).to eq [
         tag('head', 'The Rock (1996) - IMDb'),
         tag('og:site_name', 'IMDb'),
         tag('og:title', 'The Rock (1996)'),
@@ -80,7 +80,7 @@ describe Crystal::Tags do
 
   context '#find_by_name' do
     it 'returns first tag' do
-      new('og' => {'image' => %w{1.png 2.png}}).find_by_name(:"og:image").value.should == '1.png'
+      expect(new('og' => {'image' => %w{1.png 2.png}}).find_by_name(:"og:image").value).to eq '1.png'
     end
 
     it 'raises an error if tag was not found' do
@@ -101,7 +101,7 @@ describe Crystal::Tags do
 
     context 'without pattern' do
       it 'returns all tags' do
-        subject.filter.should == [
+        expect(subject.filter).to eq [
           tag('fb:admins', '322132'),
           tag('og:image',  '1.png'),
           tag('og:image',  '2.png'),
@@ -112,7 +112,7 @@ describe Crystal::Tags do
 
     context 'with string' do
       it 'returns tags with this name' do
-        subject.filter('og:image').should == [
+        expect(subject.filter('og:image')).to eq [
           tag('og:image', '1.png'),
           tag('og:image', '2.png')
         ]
@@ -121,7 +121,7 @@ describe Crystal::Tags do
 
     context 'with regexp' do
       it 'returns tags with names matched regexp' do
-        subject.filter(/og/).should == [
+        expect(subject.filter(/og/)).to eq [
           tag('og:image', '1.png'),
           tag('og:image', '2.png'),
           tag('og:title', 'Title')


### PR DESCRIPTION
This updates crystalmeta to work with Rails 5.1. Note that it is not backwards compatible, so I recommend you bump a major version.